### PR TITLE
CBD-5349: Allow use of "null" values in databaseCompare to mark fields that should not be set

### DIFF
--- a/nest/.gitignore
+++ b/nest/.gitignore
@@ -32,3 +32,6 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# .env files
+*.env

--- a/nest/src/database.service.ts
+++ b/nest/src/database.service.ts
@@ -250,8 +250,6 @@ export class DatabaseService {
    */
   private findAndRemoveUndefined(record: Record<string, unknown>): Array<string> {
     let res = []
-    record.forEach
-
     for (let key in record) {
       if (record[key] === null) {
         res.push(key)

--- a/nest/src/database.service.ts
+++ b/nest/src/database.service.ts
@@ -98,6 +98,8 @@ class Impl {
   }
 }
 
+// This class holds the keys of the fields which runs should not have (i.e. Runs which have these fields will be exluded)
+// Currently we use the value `null' to mark fields that should be excluded. This could change in the future. 
 class ExcludedDatabaseCompareFields {
   // An array containing the names of the cluster fields to be excluded
   cluster?: Array<string>;
@@ -120,7 +122,7 @@ export class DatabaseService {
    * Used for both the Simplified and Full graphs.
    */
   async getRuns(compare: DatabaseCompare, groupBy: string): Promise<Array<Run>> {
-    console.info("Database Compare Vars = " + JSON.stringify(compare.vars))
+    console.info("Database Compare Vars = " + compare.vars)
 
     let excludedFields = this.findAndRemoveExcluded(compare);
 
@@ -245,10 +247,10 @@ export class DatabaseService {
   }
 
   /**
-   * Given a record, it finds all entries where the value is undefined, removes them and returns
+   * Given a record, it finds all entries where the value is null, removes them and returns
    * an array containing the keys of those entries
    */
-  private findAndRemoveUndefined(record: Record<string, unknown>): Array<string> {
+  private findAndRemoveNull(record: Record<string, unknown>): Array<string> {
     let res = []
     for (let key in record) {
       if (record[key] === null) {
@@ -266,16 +268,16 @@ export class DatabaseService {
     let res = new ExcludedDatabaseCompareFields()
 
     if (compare?.cluster) {
-      res.cluster = this.findAndRemoveUndefined(compare.cluster)
+      res.cluster = this.findAndRemoveNull(compare.cluster)
     }
     if (compare?.impl) {
-      res.impl = this.findAndRemoveUndefined(compare.impl)
+      res.impl = this.findAndRemoveNull(compare.impl)
     }
     if (compare?.vars) {
-      res.vars = this.findAndRemoveUndefined(compare.vars)
+      res.vars = this.findAndRemoveNull(compare.vars)
     }
     if (compare?.workload) {
-      res.workload = this.findAndRemoveUndefined(compare.workload)
+      res.workload = this.findAndRemoveNull(compare.workload)
     }
     return res
   }

--- a/vue/src/components/Shared.vue
+++ b/vue/src/components/Shared.vue
@@ -177,7 +177,7 @@ export const defaultVarsWithoutHorizontalScaling = {
   "api": "DEFAULT",
 
   // undefined is not yet supported - when it is, we will usually not want to include experiments.
-  // "experimentName": undefined
+  "experimentName": null,
 }
 
 export const defaultVars = {

--- a/vue/src/components/Shared.vue
+++ b/vue/src/components/Shared.vue
@@ -176,7 +176,8 @@ export const defaultVarsWithoutHorizontalScaling = {
   // Mainly affects Java - if there are multiple APIs, just use the default one.
   "api": "DEFAULT",
 
-  // undefined is not yet supported - when it is, we will usually not want to include experiments.
+  // We usually don't want to include experiments. The value `null` here means that runs where the field "experimentName" is defined
+  // should be excluded. The value that marks a field that should be excluded might change in the future
   "experimentName": null,
 }
 


### PR DESCRIPTION
This is a temporary solution, I still want to see if I can do something more generic to require the absence of variables.