### PR TITLE
Remove defaultCluster params that don't get recorded in the most recent runs

### DIFF
--- a/vue/src/components/Shared.vue
+++ b/vue/src/components/Shared.vue
@@ -97,15 +97,11 @@ export default {
 export const defaultCluster = {
   "type": "unmanaged",
   "memory": 28000,
-  "region": "us-east-2",
   "storage": "couchstore",
   "version": "7.1.1-3175-enterprise",
   "cpuCount": 16,
-  "instance": "c5.4xlarge",
   "replicas": 0,
-  "topology": "A",
   "nodeCount": 1,
-  "compaction": "disabled",
   "connectionString": "couchbase://localhost"
 }
 


### PR DESCRIPTION
The newer runs don't record the `region`, `instance`, `topology` and `compaction` parameters for the cluster (and some have a different value for the region). Remove these parameters so the runs appear in the UI