### PR TITLE
Fix: Handle the scenario where the requested runId does not exist in the PostgreSQL database

### DIFF
--- a/nest/src/dashboard.service.ts
+++ b/nest/src/dashboard.service.ts
@@ -424,6 +424,10 @@ export class DashboardService {
       input: Single,
   ): Promise<any> {
     const runs = await this.database.getRunsById([input.runId]);
+    if (runs.length === 0) {
+      // Throw an error to indicate that the request cannot be fulfilled
+      throw Error(`Run with ID ${input.runId} not found.`);
+    }
     const i: Input = {
       ...input,
       hAxis: {


### PR DESCRIPTION
Fix: Handle the scenario where the requested runId does not exist in the PostgreSQL database

            1. Fast fail the request when getRunsById returns empty list