### PR TITLE
fix: reload bar charts when cluster version changes

### DIFF
--- a/app/(home)/_components/home-content.tsx
+++ b/app/(home)/_components/home-content.tsx
@@ -207,6 +207,7 @@ export default function HomeContent({ initialData }: HomeContentProps) {
   const handleExcludeSnapshotsChange = (checked: boolean) => setExcludeSnapshots(checked)
   const { handleRefresh } = useRefreshHandler(() => setReloadTrigger(prev => prev + 1))
   const handleClusterVersionsChange = useCallback((versions: string[]) => setSelectedClusterVersions(versions), [])
+  const activeClusterVersion = selectedClusterVersions[0] ?? DEFAULT_CLUSTERS[0]
 
   const toggleOperation = useCallback((operationId: string) => {
     if (visibleOperations.includes(operationId)) {
@@ -317,6 +318,7 @@ export default function HomeContent({ initialData }: HomeContentProps) {
           selectedMetric={selectedMetric}
           onMetricChange={setSelectedMetric}
           currentSdk={currentSdk}
+          clusterVersion={activeClusterVersion}
           excludeSnapshots={excludeSnapshots}
           reloadTrigger={reloadTrigger}
           visibleOperations={visibleOperations}

--- a/app/(home)/_components/sections/OperationsSection.tsx
+++ b/app/(home)/_components/sections/OperationsSection.tsx
@@ -24,6 +24,7 @@ import {
 
 interface OperationsSectionProps {
   currentSdk: string;
+  clusterVersion: string;
   excludeSnapshots: boolean;
   selectedMetric: string;
   reloadTrigger: number;
@@ -41,6 +42,7 @@ interface OperationsSectionProps {
 
 export default function OperationsSection({
   currentSdk,
+  clusterVersion,
   excludeSnapshots,
   selectedMetric,
   reloadTrigger,
@@ -90,7 +92,8 @@ export default function OperationsSection({
             operationMap[operation.id as keyof typeof operationMap] || 'get',
             excludeSnapshots,
             true, // excludeGerrit
-            selectedMetric
+            selectedMetric,
+            clusterVersion
           )
 
           return (
@@ -99,7 +102,7 @@ export default function OperationsSection({
                 input={dashboardInput}
                 title={`${operation.title} - ${sdkInfo?.name}`}
                 description={operation.description}
-                keyProp={`${operation.id}-${currentSdk}-${excludeSnapshots}`}
+                keyProp={`${operation.id}-${currentSdk}-${excludeSnapshots}-${clusterVersion}`}
                 selectedMetric={selectedMetric}
                 threads={operation.threads}
               />
@@ -132,7 +135,8 @@ export default function OperationsSection({
             sdkInfo?.name || 'Java',
             excludeSnapshots,
             true, // excludeGerrit
-            selectedMetric
+            selectedMetric,
+            clusterVersion
           )
 
           return (
@@ -141,7 +145,7 @@ export default function OperationsSection({
                 input={dashboardInput}
                 title={`${operation.title} - ${sdkInfo?.name}`}
                 description={operation.description}
-                keyProp={`${operation.id}-${currentSdk}-${excludeSnapshots}-${reloadTrigger}`}
+                keyProp={`${operation.id}-${currentSdk}-${excludeSnapshots}-${clusterVersion}-${reloadTrigger}`}
                 selectedMetric={selectedMetric}
                 threads={20}
               />
@@ -179,7 +183,8 @@ export default function OperationsSection({
             sdkInfo?.name || 'Java',
             metric.metric,
             excludeSnapshots,
-            true // excludeGerrit
+            true, // excludeGerrit
+            clusterVersion
           )
 
           return (
@@ -188,7 +193,7 @@ export default function OperationsSection({
                 input={dashboardInput}
                 title={`${metric.title} - ${sdkInfo?.name}`}
                 description={metric.description}
-                keyProp={`${metric.id}-${currentSdk}-${excludeSnapshots}-${reloadTrigger}`}
+                keyProp={`${metric.id}-${currentSdk}-${excludeSnapshots}-${clusterVersion}-${reloadTrigger}`}
                 selectedMetric={selectedMetric}
                 threads={20}
               />
@@ -225,13 +230,15 @@ export default function OperationsSection({
                 sdkInfo?.name || 'Java',
                 threads,
                 excludeSnapshots,
-                true // excludeGerrit
+                true, // excludeGerrit
+                clusterVersion
               )
             : createTransactionInput(
                 sdkInfo?.name || 'Java',
                 threads,
                 excludeSnapshots,
-                true // excludeGerrit
+                true, // excludeGerrit
+                clusterVersion
               )
 
           return (
@@ -240,7 +247,7 @@ export default function OperationsSection({
                 input={dashboardInput}
                 title={`${operation.title} - ${sdkInfo?.name}`}
                 description={operation.description}
-                keyProp={`${operation.id}-${currentSdk}-${excludeSnapshots}-${reloadTrigger}`}
+                keyProp={`${operation.id}-${currentSdk}-${excludeSnapshots}-${clusterVersion}-${reloadTrigger}`}
                 selectedMetric={selectedMetric}
                 threads={operation.threads}
               />
@@ -277,7 +284,8 @@ export default function OperationsSection({
               dashboardInput = createHorizontalScalingReactiveInput(
                 sdkInfo?.name || 'Java',
                 excludeSnapshots,
-                true // excludeGerrit
+                true, // excludeGerrit
+                clusterVersion
               )
               break
             case 'kvGetsBlocking':
@@ -286,7 +294,8 @@ export default function OperationsSection({
                 sdkInfo?.name || 'Java',
                 'DEFAULT',
                 excludeSnapshots,
-                true // excludeGerrit
+                true, // excludeGerrit
+                clusterVersion
               )
               break
             case 'kvGetsReactive':
@@ -295,7 +304,8 @@ export default function OperationsSection({
                 sdkInfo?.name || 'Java',
                 'ASYNC',
                 excludeSnapshots,
-                true // excludeGerrit
+                true, // excludeGerrit
+                clusterVersion
               )
               break
             default:
@@ -305,7 +315,8 @@ export default function OperationsSection({
                 'get',
                 excludeSnapshots,
                 true,
-                selectedMetric
+                selectedMetric,
+                clusterVersion
               )
           }
 
@@ -315,7 +326,7 @@ export default function OperationsSection({
                 input={dashboardInput}
                 title={`${operation.title} - ${sdkInfo?.name}`}
                 description={operation.description}
-                keyProp={`${operation.id}-${currentSdk}-${excludeSnapshots}-${reloadTrigger}`}
+                keyProp={`${operation.id}-${currentSdk}-${excludeSnapshots}-${clusterVersion}-${reloadTrigger}`}
                 selectedMetric={selectedMetric}
                 threads={20}
               />

--- a/app/(home)/_components/sections/OperationsSection.tsx
+++ b/app/(home)/_components/sections/OperationsSection.tsx
@@ -102,7 +102,7 @@ export default function OperationsSection({
                 input={dashboardInput}
                 title={`${operation.title} - ${sdkInfo?.name}`}
                 description={operation.description}
-                keyProp={`${operation.id}-${currentSdk}-${excludeSnapshots}-${clusterVersion}`}
+                keyProp={`${operation.id}-${currentSdk}-${excludeSnapshots}-${clusterVersion}-${reloadTrigger}`}
                 selectedMetric={selectedMetric}
                 threads={operation.threads}
               />

--- a/app/(home)/_components/sections/TabsSection.tsx
+++ b/app/(home)/_components/sections/TabsSection.tsx
@@ -10,6 +10,7 @@ interface TabsSectionProps {
   selectedMetric: string
   onMetricChange: (metric: string) => void
   currentSdk: string
+  clusterVersion: string
   excludeSnapshots: boolean
   reloadTrigger: number
   visibleOperations: string[]
@@ -31,6 +32,7 @@ export function TabsSection({
   selectedMetric,
   onMetricChange,
   currentSdk,
+  clusterVersion,
   excludeSnapshots,
   reloadTrigger,
   visibleOperations,
@@ -63,6 +65,7 @@ export function TabsSection({
         
         <OperationsSection
           currentSdk={currentSdk}
+          clusterVersion={clusterVersion}
           excludeSnapshots={excludeSnapshots}
           selectedMetric={selectedMetric}
           reloadTrigger={reloadTrigger}

--- a/src/lib/dashboard/queries.ts
+++ b/src/lib/dashboard/queries.ts
@@ -100,13 +100,24 @@ export class ErrorSummary {
 // Import consolidated axis utilities
 import { HorizontalAxisDynamicUtil } from './axis';
 
+const resolveClusterVersion = (clusterVersion?: string) => {
+  if (clusterVersion && clusterVersion.trim().length > 0) return clusterVersion
+  return DEFAULT_CLUSTER.version
+}
+
+const buildClusterConfig = (clusterVersion?: string) => ({
+  ...DEFAULT_CLUSTER,
+  version: resolveClusterVersion(clusterVersion)
+})
+
 // Input builder functions
 export function createKVOperationInput(
   language: string, 
   operation: 'get' | 'replace' | 'insert',
   excludeSnapshots: boolean = false,
   excludeGerrit: boolean = true,
-  metricColumn: string = "duration_average_us"
+  metricColumn: string = "duration_average_us",
+  clusterVersion?: string
 ): DashboardInput {
   const actualLanguage = LANGUAGE_MAP[language] || language
 
@@ -138,7 +149,7 @@ export function createKVOperationInput(
       yAxisID: "y"
     }],
     databaseCompare: {
-      cluster: DEFAULT_CLUSTER,
+      cluster: buildClusterConfig(clusterVersion),
       impl: { language: actualLanguage },
       workload: workload,
       vars: vars
@@ -157,7 +168,8 @@ export function createSystemMetricInput(
   language: string,
   metric: string,
   excludeSnapshots: boolean = false,
-  excludeGerrit: boolean = true  
+  excludeGerrit: boolean = true,
+  clusterVersion?: string
 ): DashboardInput {
   const actualLanguage = LANGUAGE_MAP[language] || language
 
@@ -188,7 +200,7 @@ export function createSystemMetricInput(
       yAxisID: "y"
     }],
     databaseCompare: {
-      cluster: DEFAULT_CLUSTER,
+      cluster: buildClusterConfig(clusterVersion),
       impl: { language: actualLanguage },
       workload: DEFAULT_WORKLOAD_GET,
       vars: DEFAULT_QUERY_VARS
@@ -207,7 +219,8 @@ export function createHorizontalScalingInput(
   language: string,
   excludeSnapshots: boolean = false,
   excludeGerrit: boolean = true,
-  metricColumn: string = "duration_average_us"
+  metricColumn: string = "duration_average_us",
+  clusterVersion?: string
 ): DashboardInput {
   const actualLanguage = LANGUAGE_MAP[language] || language
 
@@ -227,7 +240,7 @@ export function createHorizontalScalingInput(
       yAxisID: "y"
     }],
     databaseCompare: {
-      cluster: DEFAULT_CLUSTER,
+      cluster: buildClusterConfig(clusterVersion),
       impl: { language: actualLanguage },
       workload: DEFAULT_WORKLOAD_GET,
       // CRITICAL FIX: Add experimentName: "horizontalScaling" to match Vue exactly
@@ -249,7 +262,8 @@ export function createTransactionInput(
   language: string,
   threads: number,
   excludeSnapshots: boolean = false,
-  excludeGerrit: boolean = true
+  excludeGerrit: boolean = true,
+  clusterVersion?: string
 ): DashboardInput {
   const actualLanguage = LANGUAGE_MAP[language] || language
 
@@ -266,7 +280,7 @@ export function createTransactionInput(
       yAxisID: "y"
     }],
     databaseCompare: {
-      cluster: DEFAULT_CLUSTER,
+      cluster: buildClusterConfig(clusterVersion),
       impl: { language: actualLanguage },
       // CRITICAL: Vue uses special transaction workload with transaction.ops structure
       workload: {
@@ -302,7 +316,8 @@ export function createTransactionReadOnlyInput(
   language: string,
   threads: number,
   excludeSnapshots: boolean = false,
-  excludeGerrit: boolean = true
+  excludeGerrit: boolean = true,
+  clusterVersion?: string
 ): DashboardInput {
   const actualLanguage = LANGUAGE_MAP[language] || language
 
@@ -318,7 +333,7 @@ export function createTransactionReadOnlyInput(
       yAxisID: "y"
     }],
     databaseCompare: {
-      cluster: DEFAULT_CLUSTER,
+      cluster: buildClusterConfig(clusterVersion),
       impl: { language: actualLanguage },
       // CRITICAL: Vue readonly transactions only do one get operation
       workload: {
@@ -351,7 +366,8 @@ export function createReactiveAPIInput(
   language: string,
   apiType: 'DEFAULT' | 'ASYNC',
   excludeSnapshots: boolean = false,
-  excludeGerrit: boolean = true
+  excludeGerrit: boolean = true,
+  clusterVersion?: string
 ): DashboardInput {
   const actualLanguage = LANGUAGE_MAP[language] || language
 
@@ -367,7 +383,7 @@ export function createReactiveAPIInput(
       yAxisID: "y"
     }],
     databaseCompare: {
-      cluster: DEFAULT_CLUSTER,
+      cluster: buildClusterConfig(clusterVersion),
       impl: { language: actualLanguage },
       workload: DEFAULT_WORKLOAD_GET,
       // CRITICAL: Vue reactive queries use different API setting and poolSize
@@ -386,7 +402,8 @@ export function createReactiveAPIInput(
 export function createHorizontalScalingReactiveInput(
   language: string,
   excludeSnapshots: boolean = false,
-  excludeGerrit: boolean = true
+  excludeGerrit: boolean = true,
+  clusterVersion?: string
 ): DashboardInput {
   const actualLanguage = LANGUAGE_MAP[language] || language
   
@@ -405,7 +422,7 @@ export function createHorizontalScalingReactiveInput(
       yAxisID: "y"
     }],
     databaseCompare: {
-      cluster: DEFAULT_CLUSTER,
+      cluster: buildClusterConfig(clusterVersion),
       impl: { language: actualLanguage },
       workload: DEFAULT_WORKLOAD_GET,
       // CRITICAL: Vue reactive horizontal scaling uses ASYNC API and experimentName

--- a/src/lib/dashboard/queries.ts
+++ b/src/lib/dashboard/queries.ts
@@ -102,7 +102,7 @@ import { HorizontalAxisDynamicUtil } from './axis';
 
 const resolveClusterVersion = (clusterVersion?: string) => {
   const normalized = clusterVersion?.trim()
-  if (normalized && normalized.length > 0) return normalized
+  if (normalized) return normalized
   return DEFAULT_CLUSTER.version
 }
 

--- a/src/lib/dashboard/queries.ts
+++ b/src/lib/dashboard/queries.ts
@@ -101,7 +101,8 @@ export class ErrorSummary {
 import { HorizontalAxisDynamicUtil } from './axis';
 
 const resolveClusterVersion = (clusterVersion?: string) => {
-  if (clusterVersion && clusterVersion.trim().length > 0) return clusterVersion
+  const normalized = clusterVersion?.trim()
+  if (normalized && normalized.length > 0) return normalized
   return DEFAULT_CLUSTER.version
 }
 


### PR DESCRIPTION
This PR fixes the bug where the performance bar charts dont reload (refetch data) on changing the cluster version.