### PR TITLE
SDKQE-3838: Refine cluster version display with single-select and curated versions

### DIFF
--- a/app/(home)/_components/home-content.tsx
+++ b/app/(home)/_components/home-content.tsx
@@ -41,10 +41,10 @@ interface HomeContentProps {
 
 export default function HomeContent({ initialData }: HomeContentProps) {
   const searchParams = useSearchParams()
-  
+
   const [activeTab, setActiveTab] = useState("classic")
   const [excludeSnapshots, setExcludeSnapshots] = useState(true)
-  const [selectedClusterVersions, setSelectedClusterVersions] = useState<string[]>([...DEFAULT_CLUSTERS])
+  const [selectedClusterVersion, setSelectedClusterVersion] = useState<string>(DEFAULT_CLUSTERS[0])
   const [visibleOperations, setVisibleOperations] = useState<string[]>(CORE_OPERATIONS.slice(0, 3).map((op) => op.id))
   const [visibleScaling, setVisibleScaling] = useState<string[]>(SCALING_OPERATIONS.map((op) => op.id))
   const [visibleMetrics, setVisibleMetrics] = useState<string[]>(SYSTEM_METRICS.map((op) => op.id))
@@ -58,7 +58,6 @@ export default function HomeContent({ initialData }: HomeContentProps) {
 
   // Derived from queries
   const [allVersions, setAllVersions] = useState<string[]>([])
-  const [allClusters, setAllClusters] = useState<string[]>(['7.1.1-3175-enterprise'])
   const [reloadTrigger, setReloadTrigger] = useState(0)
 
   // Load versions and clusters with React Query
@@ -70,13 +69,7 @@ export default function HomeContent({ initialData }: HomeContentProps) {
     refetchOnWindowFocus: true,
     staleTime: 0,
   })
-  const clustersQuery = useQuery({
-    queryKey: ['clusters'],
-    queryFn: async () => apiClient.getClusters(),
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: true,
-    staleTime: 0,
-  })
+
 
   // Runs query (refetch every time the page becomes active)
   const runsQuery = useQuery({
@@ -121,18 +114,7 @@ export default function HomeContent({ initialData }: HomeContentProps) {
     }
   }, [versionsQuery.data, includeSnapshots])
 
-  useEffect(() => {
-    if (clustersQuery.data?.success) {
-      setAllClusters(clustersQuery.data.data)
-      logger.debug('Loaded clusters:', { count: clustersQuery.data.data.length })
-      if (!selectedClusterVersions || selectedClusterVersions.length === 0) {
-        const defaults = DEFAULT_CLUSTERS.filter((c) => clustersQuery.data!.data.includes(c))
-        if (defaults.length > 0) {
-          setSelectedClusterVersions(defaults)
-        }
-      }
-    }
-  }, [clustersQuery.data])
+
 
   // SDK change logging
   useEffect(() => {
@@ -171,43 +153,48 @@ export default function HomeContent({ initialData }: HomeContentProps) {
     if (isLoading || !runsData || (runsData as any[]).length === 0) {
       return []
     }
-    
+
     let relevantRuns = (runsData as any[]).filter((run: any) => {
       const clusterVersion = run.params?.cluster?.version || ''
       const statusMatch = run.status === 'completed'
-      const clusterMatch = selectedClusterVersions.length === 0 || selectedClusterVersions.includes(clusterVersion)
+      const clusterMatch = clusterVersion === selectedClusterVersion
       const version: string = run.params?.impl?.version || ''
       const isGerrit = version.startsWith('refs/')
       return clusterMatch && statusMatch && !isGerrit
     })
 
     if (excludeSnapshots) {
-      relevantRuns = relevantRuns.filter(run => 
+      relevantRuns = relevantRuns.filter(run =>
         !run.params.impl?.version?.includes('-')
       )
     }
 
     return relevantRuns
-  }, [runsData, selectedClusterVersions, excludeSnapshots, isLoading])
+  }, [runsData, selectedClusterVersion, excludeSnapshots, isLoading])
 
   // Chart data using shared utilities
   const chartData = useMemo(() => {
     return aggregateHomeChartData(
       filteredRuns,
-      selectedClusterVersions,
+      [selectedClusterVersion],
       currentSdk,
       selectedMetric,
       allVersions,
       [...ALL_OPERATIONS],
       getSdkVersionById
     )
-  }, [filteredRuns, selectedClusterVersions, currentSdk, selectedMetric, allVersions])
+  }, [filteredRuns, selectedClusterVersion, currentSdk, selectedMetric, allVersions])
 
   // Event handlers
   const handleExcludeSnapshotsChange = (checked: boolean) => setExcludeSnapshots(checked)
-  const { handleRefresh } = useRefreshHandler(() => setReloadTrigger(prev => prev + 1))
-  const handleClusterVersionsChange = useCallback((versions: string[]) => setSelectedClusterVersions(versions), [])
-  const activeClusterVersion = selectedClusterVersions[0] ?? DEFAULT_CLUSTERS[0]
+  const { handleRefresh } = useRefreshHandler(async () => {
+    await Promise.all([
+      runsQuery.refetch(),
+      versionsQuery.refetch(),
+    ])
+    setReloadTrigger(prev => prev + 1)
+  })
+  const activeClusterVersion = selectedClusterVersion || DEFAULT_CLUSTERS[0]
 
   const toggleOperation = useCallback((operationId: string) => {
     if (visibleOperations.includes(operationId)) {
@@ -251,14 +238,10 @@ export default function HomeContent({ initialData }: HomeContentProps) {
 
   const generateTitle = useCallback(() => {
     const sdkInfo = getSdkVersionById(currentSdk)
-    const clusterCount = selectedClusterVersions.length
-
-    if (clusterCount === 1) {
-      return `${sdkInfo?.name || "SDK"} Performance: Cluster ${selectedClusterVersions[0]}`
-    } else {
-      return `${sdkInfo?.name || "SDK"} Performance: Multiple Clusters`
-    }
-  }, [currentSdk, selectedClusterVersions])
+    const versionMatch = selectedClusterVersion.match(/^(\d+\.\d+\.\d+)/)
+    const versionLabel = versionMatch ? versionMatch[1] : selectedClusterVersion
+    return `${sdkInfo?.name || "SDK"} Performance: Cluster ${versionLabel}`
+  }, [currentSdk, selectedClusterVersion])
 
   const exportAllData = useCallback(() => {
     if (!chartData) return
@@ -297,7 +280,7 @@ export default function HomeContent({ initialData }: HomeContentProps) {
     <AppLayout>
       <div className="container mx-auto py-6 px-6 max-w-7xl overflow-x-hidden">
         {/* Use the new HeaderSection */}
-        <HeaderSection 
+        <HeaderSection
           title={generateTitle()}
           onRefresh={handleRefresh}
           onExport={exportAllData}
@@ -305,8 +288,8 @@ export default function HomeContent({ initialData }: HomeContentProps) {
 
         {/* Use the new FiltersSection */}
         <FiltersSection
-          selectedClusterVersions={selectedClusterVersions}
-          onClusterVersionsChange={handleClusterVersionsChange}
+          selectedClusterVersion={selectedClusterVersion}
+          onClusterVersionChange={setSelectedClusterVersion}
           excludeSnapshots={excludeSnapshots}
           onExcludeSnapshotsChange={handleExcludeSnapshotsChange}
         />

--- a/app/(home)/_components/sections/FiltersSection.tsx
+++ b/app/(home)/_components/sections/FiltersSection.tsx
@@ -1,70 +1,90 @@
 "use client"
 
+import { useState, useEffect } from "react"
 import { Checkbox } from "@/src/components/ui/checkbox"
 import { Label } from "@/src/components/ui/label"
-import VersionSelector from "@/src/components/shared/version-selector"
-import { Badge } from "@/src/components/ui/badge"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/src/components/ui/tooltip"
-import { Button } from "@/src/components/ui/button"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/src/components/ui/select"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/src/components/ui/card"
 import { getClusterVersionById, getAvailableClusterVersions } from "@/src/lib/cluster-version-service"
+import type { ClusterVersion } from "@/src/lib/cluster-version-service"
 
 interface FiltersSectionProps {
-  selectedClusterVersions: string[]
-  onClusterVersionsChange: (versions: string[]) => void
+  selectedClusterVersion: string
+  onClusterVersionChange: (version: string) => void
   excludeSnapshots: boolean
   onExcludeSnapshotsChange: (checked: boolean) => void
 }
 
 export function FiltersSection({
-  selectedClusterVersions,
-  onClusterVersionsChange,
+  selectedClusterVersion,
+  onClusterVersionChange,
   excludeSnapshots,
   onExcludeSnapshotsChange
 }: FiltersSectionProps) {
+  const [availableVersions, setAvailableVersions] = useState<ClusterVersion[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    const loadVersions = async () => {
+      try {
+        setIsLoading(true)
+        const versions = await getAvailableClusterVersions()
+        setAvailableVersions(versions)
+      } catch (err) {
+        console.error('Error fetching cluster versions:', err)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    loadVersions()
+  }, [])
+
+  const selectedInfo = getClusterVersionById(selectedClusterVersion)
+
   return (
     <div className="grid grid-cols-1 gap-4 mb-6">
       <Card>
         <CardHeader className="pb-3">
-          <CardTitle className="text-sm font-medium">Cluster Versions</CardTitle>
-          <CardDescription>Select cluster versions to compare</CardDescription>
+          <CardTitle className="text-sm font-medium">Cluster Version</CardTitle>
+          <CardDescription>Select the cluster version to view results for</CardDescription>
         </CardHeader>
         <CardContent>
           <div className="flex flex-col gap-3">
-            <VersionSelector
-              title="Cluster Versions"
-              selectedVersions={selectedClusterVersions}
-              onChange={onClusterVersionsChange}
-              maxSelections={3}
-              fetchVersions={async () => {
-                const versions = await getAvailableClusterVersions()
-                return versions.map((version: any) => ({
-                  id: version.id,
-                  name: version.name,
-                  color: version.color
-                }))
-              }}
-              placeholder="Select Cluster Versions"
-            />
+            <div className="flex items-center gap-3">
+              <Select
+                value={selectedClusterVersion}
+                onValueChange={onClusterVersionChange}
+                disabled={isLoading}
+              >
+                <SelectTrigger className="w-[280px]">
+                  <SelectValue placeholder={isLoading ? "Loading..." : "Select Cluster Version"} />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableVersions.map((version) => (
+                    <SelectItem key={version.id} value={version.id}>
+                      <div className="flex items-center gap-2">
+                        <div
+                          className="w-3 h-3 rounded-full border"
+                          style={{ backgroundColor: version.color }}
+                        />
+                        <span>Cluster {version.name}</span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
 
-            {selectedClusterVersions.length > 0 && (
-              <div className="flex flex-wrap gap-2 mt-2">
-                {selectedClusterVersions.map((version) => {
-                  const clusterInfo = getClusterVersionById(version)
-                  return (
-                    <Badge
-                      key={version}
-                      variant="outline"
-                      className="flex items-center gap-1 px-3 py-1"
-                      style={{ borderColor: clusterInfo?.color }}
-                    >
-                      <div className="w-2 h-2 rounded-full" style={{ backgroundColor: clusterInfo?.color }} />
-                      <span>Cluster {clusterInfo?.name}</span>
-                    </Badge>
-                  )
-                })}
-              </div>
-            )}
+              {selectedInfo && (
+                <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                  <div
+                    className="w-2 h-2 rounded-full"
+                    style={{ backgroundColor: selectedInfo.color }}
+                  />
+                  <span>{selectedInfo.id}</span>
+                </div>
+              )}
+            </div>
 
             <div className="flex items-center space-x-2 pt-2 border-t">
               <Checkbox

--- a/src/components/shared/dashboard-results.tsx
+++ b/src/components/shared/dashboard-results.tsx
@@ -47,13 +47,13 @@ interface DashboardResultsProps {
 function JsonPopup({ data, title, triggerText }: { data: any, title: string, triggerText: string }) {
   const [isOpen, setIsOpen] = useState(false)
   const [copied, setCopied] = useState(false)
-  
+
   if (!data) return null
-  
+
   // Count the number of fields in the object
   const fieldCount = typeof data === 'object' ? Object.keys(data).length : 0
   const jsonString = JSON.stringify(data, null, 2)
-  
+
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(jsonString)
@@ -63,20 +63,20 @@ function JsonPopup({ data, title, triggerText }: { data: any, title: string, tri
       console.error('Failed to copy:', err)
     }
   }
-  
+
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
-        <Button 
-          variant="ghost" 
-          size="sm" 
+        <Button
+          variant="ghost"
+          size="sm"
           className="h-8 px-2 text-xs font-normal bg-blue-50 hover:bg-blue-100 border border-blue-200 rounded-md shadow-sm text-blue-700 hover:text-blue-800"
         >
           <Info className="h-3 w-3 mr-1" />
           {triggerText}
         </Button>
       </PopoverTrigger>
-      <PopoverContent 
+      <PopoverContent
         className="w-[700px] max-h-[600px] overflow-hidden p-0 shadow-2xl border border-gray-300 bg-white rounded-lg"
         align="start"
         side="top"
@@ -98,7 +98,7 @@ function JsonPopup({ data, title, triggerText }: { data: any, title: string, tri
             {copied ? 'Copied!' : 'Copy JSON'}
           </Button>
         </div>
-        
+
         {/* JSON content */}
         <div className="p-6">
           <div className="max-h-[450px] overflow-y-auto bg-gray-50 p-4 rounded-md border">
@@ -128,8 +128,8 @@ export default function DashboardResults({ input, title, description, keyProp, s
   const [errors, setErrors] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [showRuns, setShowRuns] = useState(false)
-  const [lastRequestId, setLastRequestId] = useState(0)
-  
+
+
   // Use ref to track if component is mounted to prevent state updates after unmount
   const isMountedRef = useRef(true)
   useEffect(() => {
@@ -141,18 +141,18 @@ export default function DashboardResults({ input, title, description, keyProp, s
 
   // Determine if this is a single run input
   const isSingleRun = 'runId' in input
-  
+
   // Extract SDK language from input for dynamic props
-  const sdkLanguage = !isSingleRun && 'databaseCompare' in input 
+  const sdkLanguage = !isSingleRun && 'databaseCompare' in input
     ? String((input as DashboardInput).databaseCompare?.impl?.language || 'Java')
     : 'Java'
-  
+
   // Memoize input serialization to prevent unnecessary re-renders
   // This is the key fix - we serialize the input object to detect actual changes
   const inputKey = useMemo(() => {
     return JSON.stringify(input)
   }, [input])
-  
+
   const query = useQuery({
     // CRITICAL FIX: Include title in queryKey to prevent cache conflicts between different chart types
     // This ensures each chart maintains its own cache and doesn't interfere with others
@@ -175,9 +175,9 @@ export default function DashboardResults({ input, title, description, keyProp, s
   })
 
   useEffect(() => {
-    if (query.isLoading) setIsLoading(true)
+    if (query.isFetching) setIsLoading(true)
     else setIsLoading(false)
-  }, [query.isLoading])
+  }, [query.isFetching])
 
   useEffect(() => {
     if (query.error) setErrors((query.error as Error).message)
@@ -201,10 +201,10 @@ export default function DashboardResults({ input, title, description, keyProp, s
   // Only manually refetch when keyProp changes (for SDK selection refresh)
   // FIXED: Remove 'query' from dependencies to prevent infinite loop
   useEffect(() => {
-    if (keyProp) { 
+    if (keyProp) {
       console.log("DashboardResults: Refreshing due to keyProp change", { title, keyProp })
-      // Clear state and trigger fresh fetch
-      setResults(null)
+      // Don't clear results - keep displaying existing data until new data arrives
+      // Setting results to null caused a race condition where "No data available" would flash
       setErrors(null)
       query.refetch()
     }
@@ -247,15 +247,15 @@ export default function DashboardResults({ input, title, description, keyProp, s
           return { label: "Failed Operations", unit: "ops" }
       }
     }
-    
+
     // Fallback to AVAILABLE_METRICS for duration-based metrics
-    return AVAILABLE_METRICS.find(m => m.id === selectedMetric) || 
-           { label: "Performance", unit: "units" }
+    return AVAILABLE_METRICS.find(m => m.id === selectedMetric) ||
+      { label: "Performance", unit: "units" }
   }, [input, selectedMetric])
 
   const metricInfo = getMetricInfo()
 
-  if (isLoading) {
+  if (isLoading && !results) {
     return (
       <Card className="w-full">
         <CardHeader>
@@ -295,9 +295,9 @@ export default function DashboardResults({ input, title, description, keyProp, s
             <AlertDescription>{errors}</AlertDescription>
           </Alert>
           <div className="flex gap-2 mt-4">
-            <Button 
-              onClick={handleRefresh} 
-              variant="outline" 
+            <Button
+              onClick={handleRefresh}
+              variant="outline"
               size="sm"
               disabled={isLoading}
             >
@@ -345,9 +345,17 @@ export default function DashboardResults({ input, title, description, keyProp, s
   return (
     <div className="w-full space-y-4">
       {/* Chart rendering - matches Vue Results.vue */}
-      <div className="graph">
+      <div className="graph relative">
+        {isLoading && (
+          <div className="absolute inset-0 bg-white/60 dark:bg-slate-900/60 z-10 flex items-center justify-center rounded-lg">
+            <div className="flex items-center gap-2 bg-white dark:bg-slate-800 px-4 py-2 rounded-full shadow-md border">
+              <RefreshCw className="h-4 w-4 animate-spin text-blue-500" />
+              <span className="text-sm text-muted-foreground">Refreshing...</span>
+            </div>
+          </div>
+        )}
         {results.data?.type === 'bar' && (
-          <PerformanceBarChart 
+          <PerformanceBarChart
             title={title}
             description={description}
             metric={selectedMetric}
@@ -375,7 +383,7 @@ export default function DashboardResults({ input, title, description, keyProp, s
         )}
         {results.data?.type === 'line' && (
           <>
-            <PerformanceGraph 
+            <PerformanceGraph
               runId={""}
               data={results.data?.data as any}
               title={title}
@@ -383,7 +391,7 @@ export default function DashboardResults({ input, title, description, keyProp, s
               height={400}
             />
             <div className="text-sm text-muted-foreground mt-2">
-              Time: All runs are shown starting from time '0' to allow them to be displayed together. 
+              Time: All runs are shown starting from time '0' to allow them to be displayed together.
               Mouseover points to see the wallclock times.
             </div>
           </>
@@ -429,100 +437,100 @@ export default function DashboardResults({ input, title, description, keyProp, s
           {/* Run details table - improved version */}
           {showRuns && results.data?.runs && results.data.runs.length > 0 && (
             <div className="mt-4">
-            <div className="space-y-4">
-              <h4 className="font-medium">Matched Runs ({results.data.runs.length}):</h4>
-              <div className="max-h-96 overflow-y-auto border rounded-lg">
-                <Table>
-                  <TableHeader className="sticky top-0 bg-background">
-                    <TableRow>
-                      <TableHead className="w-[140px]">Date & Time</TableHead>
-                      <TableHead className="w-[120px]">Run ID</TableHead>
-                      <TableHead className="w-[120px]">SDK Version</TableHead>
-                      <TableHead className="w-[150px]">Cluster</TableHead>
-                      <TableHead className="w-[150px]">Workload</TableHead>
-                      <TableHead className="w-[150px]">Vars</TableHead>
-                      <TableHead className="text-right w-[100px]">Actions</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {results.data.runs
-                      .sort((a: any, b: any) => {
-                        // Sort by datetime in descending order (most recent first)
-                        const dateA = new Date(a.datetime).getTime()
-                        const dateB = new Date(b.datetime).getTime()
-                        return dateB - dateA
-                      })
-                      .map((run: any, index: number) => {
-                      const runId = run.run_id || run.id || `Run ${index + 1}`
-                      const formatDate = (dateStr: string) => {
-                        try {
-                          return new Date(dateStr).toLocaleString('en-US', {
-                            year: 'numeric',
-                            month: 'short',
-                            day: 'numeric',
-                            hour: '2-digit',
-                            minute: '2-digit'
-                          })
-                        } catch {
-                          return dateStr
-                        }
-                      }
-                      
-                      return (
-                        <TableRow key={runId} className="hover:bg-muted/50">
-                          <TableCell className="font-medium text-sm">{formatDate(run.datetime)}</TableCell>
-                          <TableCell>
-                            <Badge variant="outline" className="font-mono text-xs">
-                              {runId.length > 8 ? `${runId.slice(0, 8)}...` : runId}
-                            </Badge>
-                          </TableCell>
-                          <TableCell>
-                            {run.params?.impl && (
-                              <div className="space-y-1">
-                                <SdkBadge value={run.params.impl.language} />
-                                <VersionBadge 
-                                  value={run.params.impl.version?.length > 12 
-                                    ? `${run.params.impl.version.slice(0, 12)}...` 
-                                    : run.params.impl.version}
+              <div className="space-y-4">
+                <h4 className="font-medium">Matched Runs ({results.data.runs.length}):</h4>
+                <div className="max-h-96 overflow-y-auto border rounded-lg">
+                  <Table>
+                    <TableHeader className="sticky top-0 bg-background">
+                      <TableRow>
+                        <TableHead className="w-[140px]">Date & Time</TableHead>
+                        <TableHead className="w-[120px]">Run ID</TableHead>
+                        <TableHead className="w-[120px]">SDK Version</TableHead>
+                        <TableHead className="w-[150px]">Cluster</TableHead>
+                        <TableHead className="w-[150px]">Workload</TableHead>
+                        <TableHead className="w-[150px]">Vars</TableHead>
+                        <TableHead className="text-right w-[100px]">Actions</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {results.data.runs
+                        .sort((a: any, b: any) => {
+                          // Sort by datetime in descending order (most recent first)
+                          const dateA = new Date(a.datetime).getTime()
+                          const dateB = new Date(b.datetime).getTime()
+                          return dateB - dateA
+                        })
+                        .map((run: any, index: number) => {
+                          const runId = run.run_id || run.id || `Run ${index + 1}`
+                          const formatDate = (dateStr: string) => {
+                            try {
+                              return new Date(dateStr).toLocaleString('en-US', {
+                                year: 'numeric',
+                                month: 'short',
+                                day: 'numeric',
+                                hour: '2-digit',
+                                minute: '2-digit'
+                              })
+                            } catch {
+                              return dateStr
+                            }
+                          }
+
+                          return (
+                            <TableRow key={runId} className="hover:bg-muted/50">
+                              <TableCell className="font-medium text-sm">{formatDate(run.datetime)}</TableCell>
+                              <TableCell>
+                                <Badge variant="outline" className="font-mono text-xs">
+                                  {runId.length > 8 ? `${runId.slice(0, 8)}...` : runId}
+                                </Badge>
+                              </TableCell>
+                              <TableCell>
+                                {run.params?.impl && (
+                                  <div className="space-y-1">
+                                    <SdkBadge value={run.params.impl.language} />
+                                    <VersionBadge
+                                      value={run.params.impl.version?.length > 12
+                                        ? `${run.params.impl.version.slice(0, 12)}...`
+                                        : run.params.impl.version}
+                                    />
+                                  </div>
+                                )}
+                              </TableCell>
+                              <TableCell className="p-2">
+                                <JsonPopup
+                                  data={run.params?.cluster}
+                                  title="Cluster Configuration"
+                                  triggerText="Cluster"
                                 />
-                              </div>
-                            )}
-                          </TableCell>
-                          <TableCell className="p-2">
-                            <JsonPopup
-                              data={run.params?.cluster}
-                              title="Cluster Configuration"
-                              triggerText="Cluster"
-                            />
-                          </TableCell>
-                          <TableCell className="p-2">
-                            <JsonPopup
-                              data={run.params?.workload}
-                              title="Workload Configuration"
-                              triggerText="Workload"
-                            />
-                          </TableCell>
-                          <TableCell className="p-2">
-                            <JsonPopup
-                              data={run.params?.vars}
-                              title="Variables Configuration"
-                              triggerText="Variables"
-                            />
-                          </TableCell>
-                          <TableCell className="text-right">
-                            <Button variant="ghost" size="sm" asChild>
-                              <Link href={`/run/${runId}?metric=${encodeURIComponent(selectedMetric)}`}>
-                                <ExternalLink className="h-3 w-3" />
-                              </Link>
-                            </Button>
-                          </TableCell>
-                        </TableRow>
-                      )
-                    })}
-                  </TableBody>
-                </Table>
+                              </TableCell>
+                              <TableCell className="p-2">
+                                <JsonPopup
+                                  data={run.params?.workload}
+                                  title="Workload Configuration"
+                                  triggerText="Workload"
+                                />
+                              </TableCell>
+                              <TableCell className="p-2">
+                                <JsonPopup
+                                  data={run.params?.vars}
+                                  title="Variables Configuration"
+                                  triggerText="Variables"
+                                />
+                              </TableCell>
+                              <TableCell className="text-right">
+                                <Button variant="ghost" size="sm" asChild>
+                                  <Link href={`/run/${runId}?metric=${encodeURIComponent(selectedMetric)}`}>
+                                    <ExternalLink className="h-3 w-3" />
+                                  </Link>
+                                </Button>
+                              </TableCell>
+                            </TableRow>
+                          )
+                        })}
+                    </TableBody>
+                  </Table>
+                </div>
               </div>
-            </div>
             </div>
           )}
         </CardContent>

--- a/src/lib/cluster-version-service.ts
+++ b/src/lib/cluster-version-service.ts
@@ -9,6 +9,7 @@ export interface ClusterVersion {
 }
 
 import { getClusterVersionColor as getColorFromUtils } from './core-ui-utilities'
+import { AVAILABLE_CLUSTER_VERSIONS } from '@/src/lib/config/defaults'
 
 // Cache for cluster versions
 let cachedClusterVersions: ClusterVersion[] | null = null
@@ -24,12 +25,12 @@ export async function getAvailableClusterVersions(): Promise<ClusterVersion[]> {
     // For server-side calls, import and use the database service directly
     // This avoids the fetch() issue during SSR
     let clusterIds: string[]
-    
+
     if (typeof window === 'undefined') {
       // Server-side: use database service directly
       const { getDatabaseService } = await import('@/src/lib/database-connection-pool')
       const databaseService = await getDatabaseService()
-      
+
       const query = `
         SELECT DISTINCT 
           COALESCE(params->>'cluster_version', 'unknown') as cluster_version
@@ -38,7 +39,7 @@ export async function getAvailableClusterVersions(): Promise<ClusterVersion[]> {
           AND params->>'cluster_version' != ''
         ORDER BY cluster_version
       `
-      
+
       const results = await databaseService.pool.query(query, [])
       clusterIds = results.rows.map((row: any) => row.cluster_version)
     } else {
@@ -49,13 +50,17 @@ export async function getAvailableClusterVersions(): Promise<ClusterVersion[]> {
       }
       clusterIds = await response.json()
     }
-    
+
+    // Filter to only curated cluster versions
+    // Users can run against arbitrary cluster versions, but front pages only show curated results
+    clusterIds = clusterIds.filter(id => (AVAILABLE_CLUSTER_VERSIONS as readonly string[]).includes(id))
+
     // Transform database cluster IDs into ClusterVersion objects
     const clusterVersions: ClusterVersion[] = clusterIds.map((id, index) => {
       // Extract version number from ID (e.g., "7.1.1-3175-enterprise" -> "7.1.1")
       const versionMatch = id.match(/^(\d+\.\d+\.\d+)/)
       const versionName = versionMatch ? versionMatch[1] : id
-      
+
       return {
         id: id,
         name: versionName,
@@ -65,34 +70,28 @@ export async function getAvailableClusterVersions(): Promise<ClusterVersion[]> {
         description: `Cluster version ${versionName} from performance database`
       }
     })
-    
+
     // Cache the results
     cachedClusterVersions = clusterVersions
     return clusterVersions
-    
+
   } catch (error) {
     console.error('Error fetching cluster versions:', error)
-    
-    // Fallback to default versions if API fails
-    const fallbackVersions: ClusterVersion[] = [
-      {
-        id: "7.1.1-3175-enterprise",
-        name: "7.1.1",
-        color: getColorFromUtils("7.1.1-3175-enterprise"),
-        releaseDate: "2021-09-15",
+
+    // Fallback to curated versions if API fails
+    const fallbackVersions: ClusterVersion[] = AVAILABLE_CLUSTER_VERSIONS.map((id) => {
+      const versionMatch = id.match(/^(\d+\.\d+\.\d+)/)
+      const versionName = versionMatch ? versionMatch[1] : id
+      return {
+        id,
+        name: versionName,
+        color: getColorFromUtils(id),
+        releaseDate: "2023-01-01",
         isActive: true,
-        description: "Baseline version with standard performance",
-      },
-      {
-        id: "7.1.2-3454-enterprise",
-        name: "7.1.2",
-        color: getColorFromUtils("7.1.2-3454-enterprise"),
-        releaseDate: "2022-02-10",
-        isActive: true,
-        description: "Performance improvements for KV operations",
+        description: `Cluster version ${versionName}`,
       }
-    ]
-    
+    })
+
     cachedClusterVersions = fallbackVersions
     return fallbackVersions
   }
@@ -104,11 +103,11 @@ export function getClusterVersionById(id: string): ClusterVersion | undefined {
   if (cachedClusterVersions) {
     return cachedClusterVersions.find((version) => version.id === id)
   }
-  
+
   // Fallback: create a temporary cluster version object if data isn't loaded yet
   const versionMatch = id.match(/^(\d+\.\d+\.\d+)/)
   const versionName = versionMatch ? versionMatch[1] : id
-  
+
   return {
     id: id,
     name: versionName,


### PR DESCRIPTION
Refines how cluster versions are displayed on the dashboard home page:

- Converted the cluster version selector from multi-select to single-select dropdown, since the home page focuses on SDK performance trends against a single cluster version at a time.
- Filtered cluster versions to show only curated, properly tested versions (e.g., 7.1.1, 8.0.0) instead of all versions from the database, which included cluster versions we don't have much data for.  
- Eliminated duplicate cluster version entries (e.g., multiple 7.1.1 builds) by filtering against the `AVAILABLE_CLUSTER_VERSIONS` config to match the exact cluster versions only.