### PR TITLE
SDKQE-3895: The displayed metric for transactions runs does not change

### DIFF
--- a/app/(home)/_components/sections/OperationsSection.tsx
+++ b/app/(home)/_components/sections/OperationsSection.tsx
@@ -231,14 +231,16 @@ export default function OperationsSection({
                 threads,
                 excludeSnapshots,
                 true, // excludeGerrit
-                clusterVersion
+                clusterVersion,
+                selectedMetric
               )
             : createTransactionInput(
                 sdkInfo?.name || 'Java',
                 threads,
                 excludeSnapshots,
                 true, // excludeGerrit
-                clusterVersion
+                clusterVersion,
+                selectedMetric
               )
 
           return (

--- a/src/lib/dashboard/queries.ts
+++ b/src/lib/dashboard/queries.ts
@@ -264,7 +264,8 @@ export function createTransactionInput(
   threads: number,
   excludeSnapshots: boolean = false,
   excludeGerrit: boolean = true,
-  clusterVersion?: string
+  clusterVersion?: string,
+  metricColumn: string = "duration_average_us"
 ): DashboardInput {
   const actualLanguage = LANGUAGE_MAP[language] || language
 
@@ -274,10 +275,9 @@ export function createTransactionInput(
       databaseField: "impl.version",
       resultType: "VersionSemver"
     },
-    // CRITICAL: Vue uses operations_total (throughput) for transactions, not duration_average_us
     yAxes: [{
       type: "buckets",
-      column: "operations_total",
+      column: metricColumn,
       yAxisID: "y"
     }],
     databaseCompare: {
@@ -318,7 +318,8 @@ export function createTransactionReadOnlyInput(
   threads: number,
   excludeSnapshots: boolean = false,
   excludeGerrit: boolean = true,
-  clusterVersion?: string
+  clusterVersion?: string,
+  metricColumn: string = "duration_average_us"
 ): DashboardInput {
   const actualLanguage = LANGUAGE_MAP[language] || language
 
@@ -330,7 +331,7 @@ export function createTransactionReadOnlyInput(
     },
     yAxes: [{
       type: "buckets",
-      column: "duration_average_us",  // Vue uses duration for readonly transactions
+      column: metricColumn,
       yAxisID: "y"
     }],
     databaseCompare: {


### PR DESCRIPTION
Changes
----------
- Replace hardcoded "operations_total" with metric passed in by the global metric selector

Example:
<img width="1240" height="460" alt="image" src="https://github.com/user-attachments/assets/9764daf4-0c84-4088-b073-b54a2078c331" />
