### PR TITLE
SDKQE-3881: Duplicate transactions workloads shown

### DIFF
--- a/app/(home)/_components/sections/OperationsSection.tsx
+++ b/app/(home)/_components/sections/OperationsSection.tsx
@@ -231,14 +231,16 @@ export default function OperationsSection({
                 threads,
                 excludeSnapshots,
                 true, // excludeGerrit
-                clusterVersion
+                clusterVersion,
+                selectedMetric
               )
             : createTransactionInput(
                 sdkInfo?.name || 'Java',
                 threads,
                 excludeSnapshots,
                 true, // excludeGerrit
-                clusterVersion
+                clusterVersion,
+                selectedMetric
               )
 
           return (

--- a/app/(home)/_components/sections/OperationsSection.tsx
+++ b/app/(home)/_components/sections/OperationsSection.tsx
@@ -247,7 +247,7 @@ export default function OperationsSection({
             <div key={operation.id} className="mb-6">
               <DashboardResults
                 input={dashboardInput}
-                title={`${operation.title} - ${sdkInfo?.name}`}
+                title={`${operation.title} (${operation.threads} thread${operation.threads > 1 ? 's' : ''}) - ${sdkInfo?.name}`}
                 description={operation.description}
                 keyProp={`${operation.id}-${currentSdk}-${excludeSnapshots}-${clusterVersion}-${reloadTrigger}`}
                 selectedMetric={selectedMetric}

--- a/app/(home)/_components/sections/OperationsSection.tsx
+++ b/app/(home)/_components/sections/OperationsSection.tsx
@@ -222,13 +222,10 @@ export default function OperationsSection({
         </div>
 
         {TRANSACTION_OPERATIONS.filter((op) => visibleTransactions.includes(op.id)).map((operation) => {
-          // CRITICAL FIX: Use proper transaction query functions to match Vue exactly
-          const threads = operation.id.includes('1') ? 1 : 20
-          
           const dashboardInput = operation.type === 'readonly'
             ? createTransactionReadOnlyInput(
                 sdkInfo?.name || 'Java',
-                threads,
+                operation.threads,
                 excludeSnapshots,
                 true, // excludeGerrit
                 clusterVersion,
@@ -236,7 +233,7 @@ export default function OperationsSection({
               )
             : createTransactionInput(
                 sdkInfo?.name || 'Java',
-                threads,
+                operation.threads,
                 excludeSnapshots,
                 true, // excludeGerrit
                 clusterVersion,

--- a/src/lib/dashboard/queries.ts
+++ b/src/lib/dashboard/queries.ts
@@ -264,7 +264,8 @@ export function createTransactionInput(
   threads: number,
   excludeSnapshots: boolean = false,
   excludeGerrit: boolean = true,
-  clusterVersion?: string
+  clusterVersion?: string,
+  metricColumn: string = "duration_average_us"
 ): DashboardInput {
   const actualLanguage = LANGUAGE_MAP[language] || language
 
@@ -274,10 +275,9 @@ export function createTransactionInput(
       databaseField: "impl.version",
       resultType: "VersionSemver"
     },
-    // CRITICAL: Vue uses operations_total (throughput) for transactions, not duration_average_us
     yAxes: [{
       type: "buckets",
-      column: "operations_total",
+      column: metricColumn,
       yAxisID: "y"
     }],
     databaseCompare: {
@@ -318,7 +318,8 @@ export function createTransactionReadOnlyInput(
   threads: number,
   excludeSnapshots: boolean = false,
   excludeGerrit: boolean = true,
-  clusterVersion?: string
+  clusterVersion?: string,
+  metricColumn: string = "duration_average_us"
 ): DashboardInput {
   const actualLanguage = LANGUAGE_MAP[language] || language
 
@@ -330,7 +331,7 @@ export function createTransactionReadOnlyInput(
     },
     yAxes: [{
       type: "buckets",
-      column: "duration_average_us",  // Vue uses duration for readonly transactions
+      column: metricColumn,
       yAxisID: "y"
     }],
     databaseCompare: {


### PR DESCRIPTION
Changes
----------
- Add number of threads to transactions workload label

Example:
<img width="982" height="827" alt="image" src="https://github.com/user-attachments/assets/520f1cb9-1334-494a-b546-5660e987af77" />
