### PR TITLE
SDKQE-3888: Show timezone used for timestamps

### DIFF
--- a/app/faas/job/[jobId]/page.tsx
+++ b/app/faas/job/[jobId]/page.tsx
@@ -169,7 +169,7 @@ export default function FaasJobDetailPage({ params }: { params: Promise<{ jobId:
             <CardContent>
               <div className="space-y-1">
                 <p className="text-lg font-semibold">{formatDateShort(faasJob.datetime as any)}</p>
-                <p className="text-sm text-muted-foreground">{new Date(faasJob.datetime as any).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })}</p>
+                <p className="text-sm text-muted-foreground">{new Date(faasJob.datetime as any).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', timeZoneName: 'short' })}</p>
               </div>
             </CardContent>
           </Card>

--- a/app/faas/jobs/page.tsx
+++ b/app/faas/jobs/page.tsx
@@ -117,7 +117,8 @@ function FaasJobsPageContent() {
   const formatTime = (dateString: string) => {
     return new Date(dateString).toLocaleTimeString('en-US', {
       hour: '2-digit',
-      minute: '2-digit'
+      minute: '2-digit',
+      timeZoneName: 'short'
     })
   }
 

--- a/app/situational/[id]/page.tsx
+++ b/app/situational/[id]/page.tsx
@@ -262,7 +262,7 @@ export default function SituationalRunDetailPage({ params }: { params: Promise<{
 
                 <div className="mb-4">
                   <p className="text-gray-500 mb-2">
-                    Started: {startedDate.toLocaleDateString()} {startedDate.toLocaleTimeString()}
+                    Started: {startedDate.toLocaleDateString()} {startedDate.toLocaleTimeString('en-US', { timeZoneName: 'short' })}
                   </p>
                   <p className="text-gray-500 text-sm">
                     <Clock className="inline-block h-3 w-3 mr-1" />
@@ -299,7 +299,7 @@ export default function SituationalRunDetailPage({ params }: { params: Promise<{
                     <TableRow key={run.id} className="hover:bg-slate-50">
                       <TableCell>{run.description}</TableCell>
                       <TableCell>
-                        {runStartedDate.toLocaleDateString()} {runStartedDate.toLocaleTimeString()}
+                        {runStartedDate.toLocaleDateString()} {runStartedDate.toLocaleTimeString('en-US', { timeZoneName: 'short' })}
                       </TableCell>
                       {/* 
                       <TableCell>
@@ -454,7 +454,7 @@ export default function SituationalRunDetailPage({ params }: { params: Promise<{
                         <div className="flex flex-col">
                           <dt className="text-sm text-muted-foreground">Started</dt>
                           <dd>
-                            {startedDate.toLocaleDateString()} {startedDate.toLocaleTimeString()}
+                            {startedDate.toLocaleDateString()} {startedDate.toLocaleTimeString('en-US', { timeZoneName: 'short' })}
                             <p className="text-gray-500 text-sm">
                               <Clock className="inline-block h-3 w-3 mr-1" />
                               {hours}h {minutes}m ago

--- a/src/components/shared/dashboard-results.tsx
+++ b/src/components/shared/dashboard-results.tsx
@@ -481,7 +481,8 @@ export default function DashboardResults({ input, title, description, keyProp, s
                                 month: 'short',
                                 day: 'numeric',
                                 hour: '2-digit',
-                                minute: '2-digit'
+                                minute: '2-digit',
+                                timeZoneName: 'short'
                               })
                             } catch {
                               return dateStr

--- a/src/lib/utils/formatting.ts
+++ b/src/lib/utils/formatting.ts
@@ -20,7 +20,7 @@ export const dateFormatters = {
         return (dateInput as any).date ?? (dateInput as any).started ?? (dateInput as any).value ?? (dateInput as any).defined ?? String(dateInput)
       })()
       const d = new Date(String(raw))
-      return Number.isFinite(d.getTime()) ? d.toLocaleString() : String(raw ?? 'Invalid date')
+      return Number.isFinite(d.getTime()) ? d.toLocaleString('en-US', { timeZoneName: 'short' }) : String(raw ?? 'Invalid date')
     } catch (e) {
       return String(dateInput ?? 'Invalid date')
     }


### PR DESCRIPTION
Changes
----------
- Set instances of DateTimeFormatOptions to use `short` i.e. the short localised form e.g. PST, GMT - 1

Example:
<img width="184" height="39" alt="image" src="https://github.com/user-attachments/assets/2218e3c1-4851-4f5d-a848-66f03057fc74" />


