### PR TITLE
SDKQE-3880: Reactive API is mentioned on SDKs where this doesn't make sense

### DIFF
--- a/app/(home)/_components/home-content.tsx
+++ b/app/(home)/_components/home-content.tsx
@@ -16,7 +16,7 @@ import {
   SCALING_OPERATIONS,
   SYSTEM_METRICS,
   TRANSACTION_OPERATIONS,
-  API_COMPARISON_OPERATIONS,
+  SDK_API_COMPARISONS,
   ALL_OPERATIONS,
   AVAILABLE_METRICS
 } from '@/src/lib/config/constants'
@@ -49,7 +49,9 @@ export default function HomeContent({ initialData }: HomeContentProps) {
   const [visibleScaling, setVisibleScaling] = useState<string[]>(SCALING_OPERATIONS.map((op) => op.id))
   const [visibleMetrics, setVisibleMetrics] = useState<string[]>(SYSTEM_METRICS.map((op) => op.id))
   const [visibleTransactions, setVisibleTransactions] = useState<string[]>(TRANSACTION_OPERATIONS.map((op) => op.id))
-  const [visibleApiComparisons, setVisibleApiComparisons] = useState<string[]>(API_COMPARISON_OPERATIONS.map((op) => op.id))
+  const [visibleApiComparisons, setVisibleApiComparisons] = useState<string[]>(
+    (Object.values(SDK_API_COMPARISONS) as readonly (typeof SDK_API_COMPARISONS[keyof typeof SDK_API_COMPARISONS])[]).flat().map((op) => op.id)
+  )
   const [selectedMetric, setSelectedMetric] = useState("duration_average_us")
   const [currentSdk, setCurrentSdk] = useState<string>(() => {
     const urlSdk = searchParams?.get('sdk')
@@ -254,7 +256,7 @@ export default function HomeContent({ initialData }: HomeContentProps) {
       ...SCALING_OPERATIONS.map(op => ({ ...op, category: 'Horizontal Scaling' })),
       ...SYSTEM_METRICS.map(op => ({ ...op, category: 'System Metrics' })),
       ...TRANSACTION_OPERATIONS.map(op => ({ ...op, category: 'Transactions' })),
-      ...API_COMPARISON_OPERATIONS.map(op => ({ ...op, category: 'API Comparisons' }))
+      ...(Object.values(SDK_API_COMPARISONS) as readonly (typeof SDK_API_COMPARISONS[keyof typeof SDK_API_COMPARISONS])[]).flat().map(op => ({ ...op, category: 'API Comparisons' }))
     ]
 
     Object.entries(chartData).forEach(([operationId, data]) => {

--- a/app/(home)/_components/home-content.tsx
+++ b/app/(home)/_components/home-content.tsx
@@ -256,7 +256,6 @@ export default function HomeContent({ initialData }: HomeContentProps) {
       ...SCALING_OPERATIONS.map(op => ({ ...op, category: 'Horizontal Scaling' })),
       ...SYSTEM_METRICS.map(op => ({ ...op, category: 'System Metrics' })),
       ...TRANSACTION_OPERATIONS.map(op => ({ ...op, category: 'Transactions' })),
-      ...(Object.values(SDK_API_COMPARISONS) as readonly (typeof SDK_API_COMPARISONS[keyof typeof SDK_API_COMPARISONS])[]).flat().map(op => ({ ...op, category: 'API Comparisons' }))
     ]
 
     Object.entries(chartData).forEach(([operationId, data]) => {

--- a/app/(home)/_components/sections/OperationsSection.tsx
+++ b/app/(home)/_components/sections/OperationsSection.tsx
@@ -10,7 +10,7 @@ import {
   SCALING_OPERATIONS,
   SYSTEM_METRICS,
   TRANSACTION_OPERATIONS,
-  API_COMPARISON_OPERATIONS
+  SDK_API_COMPARISONS
 } from "@/src/lib/config/constants"
 import { 
   createKVOperationInput, 
@@ -58,6 +58,7 @@ export default function OperationsSection({
   toggleApiComparison,
 }: OperationsSectionProps) {
   const sdkInfo = getSdkVersionById(currentSdk)
+  const sdkApiComparisons = (SDK_API_COMPARISONS as Record<string, readonly { id: string; title: string; description: string }[]>)[currentSdk] ?? []
 
   return (
     <>
@@ -257,13 +258,13 @@ export default function OperationsSection({
       </div>
 
       {/* API Comparisons Section */}
-      <div className="mb-8">
+      {sdkApiComparisons.length > 0 && <div className="mb-8">
         <div className="flex flex-wrap gap-2 mb-4">
           <div className="flex items-center mr-2">
             <BarChart4 className="h-4 w-4 mr-1 text-muted-foreground" />
             <span className="text-sm font-medium">API Comparisons:</span>
           </div>
-          {API_COMPARISON_OPERATIONS.map((operation) => (
+          {sdkApiComparisons.map((operation) => (
             <Badge
               key={operation.id}
               variant={visibleApiComparisons.includes(operation.id) ? "default" : "outline"}
@@ -275,7 +276,7 @@ export default function OperationsSection({
           ))}
         </div>
 
-        {API_COMPARISON_OPERATIONS.filter((op) => visibleApiComparisons.includes(op.id)).map((operation) => {
+        {sdkApiComparisons.filter((op) => visibleApiComparisons.includes(op.id)).map((operation) => {
           // CRITICAL FIX: Use proper reactive API query functions to match Vue exactly
           let dashboardInput
           switch (operation.id) {
@@ -333,10 +334,10 @@ export default function OperationsSection({
             </div>
           )
         })}
-      </div>
+      </div>}
 
       {visibleOperations.length === 0 && visibleScaling.length === 0 && visibleMetrics.length === 0 &&
-        visibleTransactions.length === 0 && visibleApiComparisons.length === 0 && (
+        visibleTransactions.length === 0 && (sdkApiComparisons.length === 0 || visibleApiComparisons.length === 0) && (
           <div className="bg-white rounded-lg border shadow-sm p-6 mb-8 text-center">
             <p className="text-muted-foreground">Select at least one chart type to display</p>
           </div>

--- a/src/lib/config/constants.ts
+++ b/src/lib/config/constants.ts
@@ -77,23 +77,27 @@ export const TRANSACTION_OPERATIONS = [
   }
 ] as const
 
-export const API_COMPARISON_OPERATIONS = [
-  {
-    id: "horizontalScalingReactive",
-    title: "Horizontal Scaling (Reactive)",
-    description: "Tests how the SDK scales with parallelism, using KV gets and the reactive API."
-  },
-  {
-    id: "kvGetsBlocking",
-    title: "KV Gets (Blocking API)",
-    description: "Standard blocking API performance for KV operations."
-  },
-  {
-    id: "kvGetsReactive",
-    title: "KV Gets (Reactive API)",
-    description: "Reactive/Async API performance for KV operations."
-  }
-] as const
+// API comparison operations keyed by SDK id.
+// Only SDKs whose performers support an alternate API appear here.
+export const SDK_API_COMPARISONS = {
+  java: [
+    {
+      id: "horizontalScalingReactive",
+      title: "Horizontal Scaling (Reactive)",
+      description: "Tests how the SDK scales with parallelism, using KV gets and the reactive API."
+    },
+    {
+      id: "kvGetsBlocking",
+      title: "KV Gets (Blocking API)",
+      description: "Standard blocking API performance for KV operations."
+    },
+    {
+      id: "kvGetsReactive",
+      title: "KV Gets (Reactive API)",
+      description: "Reactive/Async API performance for KV operations."
+    }
+  ]
+} as const satisfies Record<string, readonly { id: string; title: string; description: string }[]>
 
 // Combined operations list
 export const ALL_OPERATIONS = [
@@ -101,7 +105,6 @@ export const ALL_OPERATIONS = [
   ...SCALING_OPERATIONS,
   ...SYSTEM_METRICS,
   ...TRANSACTION_OPERATIONS,
-  ...API_COMPARISON_OPERATIONS
 ] as const
 
 // Available metrics for dynamic switching
@@ -139,6 +142,6 @@ export type CoreOperation = typeof CORE_OPERATIONS[number]
 export type ScalingOperation = typeof SCALING_OPERATIONS[number]
 export type SystemMetric = typeof SYSTEM_METRICS[number]
 export type TransactionOperation = typeof TRANSACTION_OPERATIONS[number]
-export type ApiComparisonOperation = typeof API_COMPARISON_OPERATIONS[number]
+export type ApiComparisonOperation = typeof SDK_API_COMPARISONS[keyof typeof SDK_API_COMPARISONS][number]
 export type Operation = typeof ALL_OPERATIONS[number]
 export type AvailableMetric = typeof AVAILABLE_METRICS[number]


### PR DESCRIPTION
Changes
---------
- Refactored `API_COMPARISONS_OPERATIONS` to be keyed SDK, to allow alternative APIs to be added on a per-sdk basis

Currently only the Java performer has support for alternative APIs, in the future if a performer adds support for a new API, it will need to be added to  the`SDK_API_COMPARISONS` const.