### PR TITLE
SDKQE-3947: Show the run id on the run detail page

### DIFF
--- a/app/(dashboard)/run/[id]/_components/RunDetailClient.tsx
+++ b/app/(dashboard)/run/[id]/_components/RunDetailClient.tsx
@@ -139,7 +139,7 @@ export default function RunDetailClient({ runData, runMetrics, runBuckets }: Run
                   Run Details
                 </CardTitle>
                 <p className="text-sm text-muted-foreground mt-1">
-                  Run ID: {runData.run_id}
+                  Run ID: {runData.id}
                 </p>
               </div>
               <div className="flex items-center gap-2">
@@ -366,7 +366,7 @@ export default function RunDetailClient({ runData, runMetrics, runBuckets }: Run
                 <CardTitle>System Metrics</CardTitle>
               </CardHeader>
               <CardContent>
-                <ObservabilityBox runId={runData.run_id} />
+                <ObservabilityBox runId={runData.id} />
               </CardContent>
             </Card>
           </TabsContent>


### PR DESCRIPTION
The header and the observability box read runData.run_id, but a run only has id, so both came out undefined: the Run ID rendered blank and the View Logs S3 path had "undefined" in it. Use runData.id in both spots.