### PR TITLE
SDKQE-3948: Fix View Logs and View in AWS S3 links

### DIFF
--- a/app/(dashboard)/run/[id]/_components/RunDetailClient.tsx
+++ b/app/(dashboard)/run/[id]/_components/RunDetailClient.tsx
@@ -366,7 +366,11 @@ export default function RunDetailClient({ runData, runMetrics, runBuckets }: Run
                 <CardTitle>System Metrics</CardTitle>
               </CardHeader>
               <CardContent>
-                <ObservabilityBox runId={runData.id} />
+                <ObservabilityBox
+                  faasJobId={runData.params?.faas?.jobId}
+                  ciUrl={runData.params?.debug?.ciUrl}
+                  date={runData.datetime}
+                />
               </CardContent>
             </Card>
           </TabsContent>

--- a/app/(dashboard)/situational/[id]/page.tsx
+++ b/app/(dashboard)/situational/[id]/page.tsx
@@ -91,6 +91,12 @@ export default function SituationalRunDetailPage({ params }: { params: Promise<{
     }
   }, [runs, resolvedParams.id])
 
+  // Only FaaS runs have S3 artifacts.
+  const faasJobId = (runs as any[]).find((r) => r.faasJobId)?.faasJobId as string | undefined
+  const situationalS3Url = faasJobId
+    ? generateS3ConsoleUrl(faasJobId, S3_CONFIG.DEFAULT_BUCKET, S3_CONFIG.DEFAULT_REGION, situationalRun.started)
+    : null
+
   // Keep the sidebar SDK highlight in sync with the detected SDK (URL side-effect).
   useEffect(() => {
     if (!situationalRun) return
@@ -138,15 +144,17 @@ export default function SituationalRunDetailPage({ params }: { params: Promise<{
           <CardContent>
             <div className="flex items-center justify-between">
               <p className="text-slate-600">Access detailed observability data for this situational run.</p>
-              <Button variant="outline" className="gap-2 border-indigo-200 text-indigo-700 hover:bg-indigo-50 hover:border-indigo-300" asChild>
-                <a
-                  href={generateS3ConsoleUrl(resolvedParams.id, S3_CONFIG.DEFAULT_BUCKET, S3_CONFIG.DEFAULT_REGION)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  View in AWS S3 <ExternalLink className="h-4 w-4" />
-                </a>
-              </Button>
+              {situationalS3Url ? (
+                <Button variant="outline" className="gap-2 border-indigo-200 text-indigo-700 hover:bg-indigo-50 hover:border-indigo-300" asChild>
+                  <a href={situationalS3Url} target="_blank" rel="noopener noreferrer">
+                    View in AWS S3 <ExternalLink className="h-4 w-4" />
+                  </a>
+                </Button>
+              ) : (
+                <Button variant="outline" className="gap-2" disabled>
+                  No S3 artifacts <ExternalLink className="h-4 w-4" />
+                </Button>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/app/(dashboard)/situational/[id]/run/[runId]/page.tsx
+++ b/app/(dashboard)/situational/[id]/run/[runId]/page.tsx
@@ -106,6 +106,7 @@ export default function SituationalRunDetailPage({
       events: data.events || [],
       errorsSummary: data.errorsSummary || [],
       ciUrl: runParams?.debug?.ciUrl,
+      faasJobId: runParams?.faas?.jobId,
       openShiftProject: runParams?.debug?.openShiftProject,
       situationalRunId: resolvedParams.id,
     }
@@ -562,8 +563,9 @@ export default function SituationalRunDetailPage({
               </Card>
 
               <ObservabilityBox
-                runId={runData.id}
-                situationalRunId={runData.situationalRunId}
+                faasJobId={runData.faasJobId}
+                ciUrl={runData.ciUrl}
+                date={runData.started}
               />
             </div>
           </TabsContent>

--- a/app/api/situational/[...params]/route.ts
+++ b/app/api/situational/[...params]/route.ts
@@ -183,6 +183,7 @@ async function handleSituationalRunsList(request: NextRequest, situationalRunId:
       environment: params?.vars?.environment ?? '-',
       status: 'completed' as const,
       ciUrl: params?.debug?.ciUrl ?? undefined,
+      faasJobId: params?.faas?.jobId ?? undefined,
     }
   })
 

--- a/src/components/shared/observability-box.tsx
+++ b/src/components/shared/observability-box.tsx
@@ -6,26 +6,30 @@ import Link from "next/link"
 import { Button } from "@/src/components/ui/button"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/src/components/ui/tooltip"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/src/components/ui/tabs"
-import { generateS3ArtifactUrl, S3_CONFIG } from "@/src/lib/utils/s3-utils"
+import { generateS3ConsoleUrl, S3_CONFIG } from "@/src/lib/utils/s3-utils"
 
 interface ObservabilityBoxProps {
-  runId: string
-  situationalRunId?: string
+  faasJobId?: string
+  ciUrl?: string
+  date?: string
   s3Bucket?: string
   s3Region?: string
 }
 
 export default function ObservabilityBox({
-  runId,
-  situationalRunId,
+  faasJobId,
+  ciUrl,
+  date,
   s3Bucket = S3_CONFIG.DEFAULT_BUCKET,
   s3Region = S3_CONFIG.DEFAULT_REGION,
 }: ObservabilityBoxProps) {
-  // Generate S3 console URLs for different artifact types
-  // Use situationalRunId as the job ID if provided, otherwise fall back to runId
-  const jobId = situationalRunId || runId
-  
-  const logsUrl = generateS3ArtifactUrl(jobId, runId, 'logs', s3Bucket, s3Region)
+  // FaaS runs store their logs in S3 under the faas job id, so we link there when a
+  // job id is present. Runs without one keep their logs at the CI run, so we fall back
+  // to ciUrl, and use it only when it is a real http(s) URL because it is sometimes a
+  // placeholder like "not-available".
+  const s3Url = faasJobId ? generateS3ConsoleUrl(faasJobId, s3Bucket, s3Region, date) : null
+  const ciHref = ciUrl && /^https?:\/\//i.test(ciUrl) ? ciUrl : null
+  const logsUrl = s3Url ?? ciHref
   return (
     <Card className="mb-6 border shadow-sm">
       <CardHeader className="pb-2">
@@ -52,7 +56,9 @@ export default function ObservabilityBox({
                 <div className="flex-1">
                   <h3 className="text-sm font-medium mb-1">Access Detailed Logs</h3>
                   <p className="text-sm text-muted-foreground mb-4">
-                    View complete execution logs for this run, including debug information and error traces.
+                    {logsUrl
+                      ? 'View complete execution logs for this run, including debug information and error traces.'
+                      : 'No execution logs were collected for this run.'}
                   </p>
                 </div>
               </div>
@@ -60,15 +66,21 @@ export default function ObservabilityBox({
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <Button variant="outline" className="w-full gap-2 justify-center" asChild>
-                      <Link href={logsUrl} target="_blank" rel="noopener noreferrer">
-                        <span>View Logs</span>
-                        <ExternalLink className="h-3.5 w-3.5" />
-                      </Link>
-                    </Button>
+                    {logsUrl ? (
+                      <Button variant="outline" className="w-full gap-2 justify-center" asChild>
+                        <Link href={logsUrl} target="_blank" rel="noopener noreferrer">
+                          <span>View Logs</span>
+                          <ExternalLink className="h-3.5 w-3.5" />
+                        </Link>
+                      </Button>
+                    ) : (
+                      <Button variant="outline" className="w-full gap-2 justify-center" disabled>
+                        <span>No logs available</span>
+                      </Button>
+                    )}
                   </TooltipTrigger>
                   <TooltipContent>
-                    <p>Open logs in AWS S3</p>
+                    <p>{s3Url ? 'Open logs in AWS S3' : ciHref ? 'Open the CI run' : 'No logs for this run'}</p>
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>

--- a/src/lib/utils/s3-utils.ts
+++ b/src/lib/utils/s3-utils.ts
@@ -14,8 +14,13 @@ function getIso8601Date(): string {
  * @param jobId - The job/situational run ID
  * @returns Formatted job ID: YYYY-MM-DD-{jobId}
  */
-function formatJobIdWithDate(jobId: string): string {
-  const isoDate = getIso8601Date()
+function formatJobIdWithDate(jobId: string, date?: string): string {
+  // Prefix with the run's date to match the S3 folder.
+  // TODO: file an SDKQE ticket. The date is the run's UTC day but the folder uses the
+  // backend's local start-date, so it can be off by a day near midnight; the backend
+  // should store the exact date so the UI doesn't have to guess.
+  const parsed = date ? new Date(date) : null
+  const isoDate = parsed && !isNaN(parsed.getTime()) ? parsed.toISOString().split('T')[0] : getIso8601Date()
   return `${isoDate}-${jobId}`
 }
 
@@ -37,40 +42,17 @@ function buildS3ConsoleUrl(bucketName: string, prefix: string, region: string = 
  * @param jobId - The job/situational run ID  
  * @param bucketName - S3 bucket name (default: fit-as-a-service-artifacts)
  * @param region - AWS region (default: us-west-2)
+ * @param date - The run's date; defaults to today
  * @returns S3 console URL for the job's artifacts
  */
 export function generateS3ConsoleUrl(
-  jobId: string, 
-  bucketName: string = 'fit-as-a-service-artifacts', 
-  region: string = 'us-west-2'
-): string {
-  const datePrefixedJobId = formatJobIdWithDate(jobId)
-  const prefix = `jobs/${datePrefixedJobId}/`
-  return buildS3ConsoleUrl(bucketName, prefix, region)
-}
-
-/**
- * Generate S3 console URL for specific artifact type (logs, metrics, cluster)
- * @param jobId - The job/situational run ID
- * @param runId - The specific run ID (optional, for more specific paths)
- * @param artifactType - Type of artifact (logs, metrics, cluster, etc.)
- * @param bucketName - S3 bucket name (default: fit-as-a-service-artifacts)  
- * @param region - AWS region (default: us-west-2)
- * @returns S3 console URL for the specific artifact type
- */
-export function generateS3ArtifactUrl(
   jobId: string,
-  runId: string | null = null,
-  artifactType: string = 'artifacts',
   bucketName: string = 'fit-as-a-service-artifacts',
-  region: string = 'us-west-2'
+  region: string = 'us-west-2',
+  date?: string
 ): string {
-  const datePrefixedJobId = formatJobIdWithDate(jobId)
-  
-  // Use the job-level prefix that matches the working URL pattern
-  // This points to the entire job directory, letting users navigate to subdirectories
+  const datePrefixedJobId = formatJobIdWithDate(jobId, date)
   const prefix = `jobs/${datePrefixedJobId}/`
-  
   return buildS3ConsoleUrl(bucketName, prefix, region)
 }
 


### PR DESCRIPTION
The links were built from the run id and today's date, so they pointed at S3 prefixes that were never written. Build the S3 link from `params.faas.jobId` and the run's date for FaaS runs, fall back to the CI run (debug.ciUrl) for direct runs, and disable the button when there is neither. Apply the same to the situational summary link.